### PR TITLE
Improve facility interactions and styling

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -36,6 +36,8 @@
       "bastionPortraitAlt": "Portrait of {name}",
       "changeBastionPortrait": "Change Bastion portrait",
       "facilityImageAlt": "Artwork for {name}",
+      "facilityArtTitle": "Facility Artwork",
+      "viewFacilityArt": "View facility art",
       "viewFacility": "View {name}",
       "freeFacilitySlot": "Free Facility Slot",
       "emptyHirelingSlot": "Empty hireling slot",
@@ -84,7 +86,8 @@
       "selectFacilityFirst": "Please select a facility first.",
       "facilityNotFound": "Selected facility could not be found.",
       "actorSelectorFailed": "Actor Selector failed. Using fallback selection.",
-      "noEligibleActors": "No eligible actors are available to assign."
+      "noEligibleActors": "No eligible actors are available to assign.",
+      "openImageFailed": "Unable to open the facility artwork preview."
     },
     "terms": {
       "hirelings": "hirelings",

--- a/src/party-bastion-sheet.js
+++ b/src/party-bastion-sheet.js
@@ -4,6 +4,23 @@
  * Party Bastion Sheet
  * A custom actor sheet for the Party Bastion, compatible with DnD5e's Bastion system
  */
+const escapeHTML = (value) => {
+  const str = value === undefined || value === null ? "" : String(value);
+  const foundryUtils = globalThis.foundry?.utils ?? {};
+  if (typeof foundryUtils.escapeHTML === "function") return foundryUtils.escapeHTML(str);
+  if (typeof foundryUtils.escapeHtml === "function") return foundryUtils.escapeHtml(str);
+
+  const entityMap = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+    "`": "&#96;"
+  };
+  return str.replace(/[&<>"'`]/g, (char) => entityMap[char] ?? char);
+};
+
 export class PartyBastionSheet extends Application {
   /**
    * @param {Actor} actor - The Party Bastion actor
@@ -168,7 +185,7 @@ r("capitalize", s =>
                 });
             } catch (err) {
                 console.error(`Shared Bastion | Error enriching facility description for ${facility.name}:`, err);
-                data.enrichedDescription = `<p><i>Error displaying description.</i></p><pre>${foundry.utils.escapeHTML(description)}</pre>`; // Fallback on error
+                data.enrichedDescription = `<p><i>Error displaying description.</i></p><pre>${escapeHTML(description)}</pre>`; // Fallback on error
             }
         }
 
@@ -283,7 +300,7 @@ r("capitalize", s =>
           });
         } catch (err) {
           console.warn(`Shared Bastion | Failed to enrich activity description for ${facility.name} (${activityId})`, err);
-          enrichedDescription = `<p>${foundry.utils.escapeHTML(descriptionRaw)}</p>`;
+          enrichedDescription = `<p>${escapeHTML(descriptionRaw)}</p>`;
         }
       }
 
@@ -398,6 +415,17 @@ r("capitalize", s =>
   activateListeners(html) {
     super.activateListeners(html);
 
+    const descriptionBody = html.find(".facility-description__body");
+    if (descriptionBody.length) {
+      TextEditor.activateListeners(descriptionBody);
+    }
+    const orderDescription = html.find(".order-description");
+    if (orderDescription.length) {
+      TextEditor.activateListeners(orderDescription);
+    }
+
+    this._applyAttributionTooltips(html);
+
     const makeKeyClickable = (selector) => {
       html.find(selector).on("keydown", ev => {
         if (ev.key === "Enter" || ev.key === " " || ev.key === "Spacebar") {
@@ -406,6 +434,10 @@ r("capitalize", s =>
         }
       });
     };
+
+    html.find(".facility-art--interactive")
+      .on("click", this._onViewFacilityArt.bind(this));
+    makeKeyClickable(".facility-art--interactive");
 
         html.find(".order-edit")
     .on("click", this._onOrderEdit.bind(this));
@@ -706,6 +738,45 @@ r("capitalize", s =>
   }
 
   /**
+   * Pop the facility art out into an ImagePopout dialog.
+   */
+  _onViewFacilityArt(event) {
+    event.preventDefault();
+    const img = event.currentTarget;
+    if (!img) return;
+
+    const src = img.dataset?.src || img.getAttribute("src");
+    if (!src) return;
+
+    const facilityId = img.dataset?.facilityId || this.selectedFacility?.id;
+    const facility = facilityId ? this.actor.items.get(facilityId) ?? this.selectedFacility : this.selectedFacility;
+    const fallbackTitle = game.i18n?.localize?.("shared-bastion.ui.facilityArtTitle")
+      || game.i18n?.localize?.("shared-bastion.ui.facilityImageAlt")
+      || "Facility Art";
+    const title = facility?.name ? `${facility.name}` : fallbackTitle;
+
+    try {
+      const popout = new ImagePopout(src, {
+        title,
+        shareable: true,
+        uuid: facility?.uuid ?? null,
+        editable: false
+      });
+      popout.render(true, { focus: true });
+    } catch (err) {
+      console.error("Shared Bastion | Failed to open facility art popout:", err);
+      ui.notifications?.error?.(game.i18n?.localize?.("shared-bastion.notifications.openImageFailed") || "Unable to open image preview.");
+      try {
+        if (typeof window !== "undefined" && typeof window.open === "function") {
+          window.open(src, "_blank");
+        }
+      } catch (fallbackErr) {
+        console.warn("Shared Bastion | Fallback image open also failed:", fallbackErr);
+      }
+    }
+  }
+
+  /**
    * Assign occupants to the selected facility
    */
   async _onAssignOccupant(event, occupantType) {
@@ -799,9 +870,10 @@ r("capitalize", s =>
     const seen = new Set();
     const pushOption = (uuid, label) => {
       if (!uuid || seen.has(uuid)) return;
-      const sanitized = foundry.utils.escapeHTML(String(label ?? unknownLabel));
+      const sanitized = escapeHTML(label ?? unknownLabel);
       const selected = currentUUIDs.includes(uuid) ? " selected" : "";
-      options.push(`<option value="${uuid}"${selected}>${sanitized}</option>`);
+      const safeValue = escapeHTML(uuid);
+      options.push(`<option value="${safeValue}"${selected}>${sanitized}</option>`);
       seen.add(uuid);
     };
 
@@ -827,10 +899,10 @@ r("capitalize", s =>
 
     const selectSize = Math.max(4, Math.min(options.length, 10));
     const content = `<form class="shared-bastion-selector">`
-      + `<p class="hint">${foundry.utils.escapeHTML(prompt)}</p>`
-      + `<div class="form-group"><label>${foundry.utils.escapeHTML(selectorTitle)}</label>`
-      + `<select name="occupants" multiple size="${selectSize}">${options.join("\n")}</select></div>`
-      + `<p class="hint">${foundry.utils.escapeHTML(hint)}</p>`
+      + `<p class="hint">${escapeHTML(prompt)}</p>`
+      + `<div class="form-group"><label>${escapeHTML(selectorTitle)}</label>`
+        + `<select name="occupants" multiple size="${selectSize}">${options.join("\n")}</select></div>`
+      + `<p class="hint">${escapeHTML(hint)}</p>`
       + `</form>`;
 
     new Dialog({
@@ -907,7 +979,26 @@ async _onOrderEdit(ev) {
   if (Hooks.call("tidy5eSheetsFacilityOrderClicked",
                  { sheet: this, actor: this.actor, facility }) === false) return;
 
-  /* 2️⃣  Bring an already-open character sheet (any class) to front */
+  /* 2️⃣  Try to open the facility’s own sheet so the user can manage activities */
+  try {
+    let sheet = facility.sheet;
+    if (!sheet) {
+      const reg = Object.values(CONFIG.Item.sheetClasses?.facility || {}).find(r => r.default);
+      const SheetClass = reg?.cls || null;
+      if (SheetClass) {
+        sheet = new SheetClass(facility, { editable: facility.isOwner });
+      }
+    }
+
+    if (sheet) {
+      sheet.render(true, { focus: true, tab: "activities" });
+      return;
+    }
+  } catch (sheetErr) {
+    console.warn("Shared Bastion | Unable to render facility sheet for order edit:", sheetErr);
+  }
+
+  /* 3️⃣  Bring an already-open character sheet (any class) to front */
   const openSheet = Object.values(this.actor.apps)
     .find(app => app !== this && app._state > 0);
   if (openSheet) {
@@ -915,7 +1006,7 @@ async _onOrderEdit(ev) {
     return;
   }
 
-  /* 3️⃣  Otherwise create the user’s *default* character sheet
+  /* 4️⃣  Otherwise create the user’s *default* character sheet
          (this is exactly the logic used by the “Character Sheet” button) */
   try {
     const reg = Object.values(CONFIG.Actor.sheetClasses.character || {})
@@ -931,6 +1022,32 @@ async _onOrderEdit(ev) {
   } catch (err) {
     console.error("Shared Bastion | order dialog fallback failed:", err);
     ui.notifications.error("Couldn’t open the Tidy5e order editor.");
+  }
+}
+
+  /**
+   * Minimal tooltip hook so Tidy5e’s attribution system has a safe target.
+   * @param {JQuery|HTMLElement|null} target
+   */
+  _applyAttributionTooltips(target = null) {
+    try {
+      const hasJQuery = typeof jQuery !== "undefined";
+      const element = target
+        ? (hasJQuery && target instanceof jQuery ? target : (hasJQuery ? $(target) : null))
+        : this.element;
+      if (!element || !element.length) return;
+
+      const applyTo = (el) => {
+        const tooltip = el.dataset?.tooltipAttribution;
+        if (!tooltip || el.hasAttribute("title")) return;
+        el.setAttribute("title", tooltip);
+      };
+
+      if (element[0]?.dataset?.tooltipAttribution) applyTo(element[0]);
+      element.find?.('[data-tooltip-attribution]').each((_, el) => applyTo(el));
+    } catch (err) {
+      console.warn("Shared Bastion | Failed to apply attribution tooltips:", err);
+    }
   }
 }
 } // End of PartyBastionSheet class

--- a/styles/shared-bastion.css
+++ b/styles/shared-bastion.css
@@ -12,6 +12,8 @@
   --sb-border-strong: rgba(255, 255, 255, 0.18);
   --sb-accent: #d7a251;
   --sb-text-muted: rgba(255, 255, 255, 0.65);
+  --sb-pane-bg: rgba(10, 12, 18, 0.7);
+  --sb-panel-bg: rgba(5, 7, 12, 0.65);
   --sb-radius: 8px;
   color: var(--color-text-light-highlight, #f1efe7);
 }
@@ -132,7 +134,7 @@
   height: 100%;
   overflow-y: auto;
   padding: 18px 22px 24px;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--sb-pane-bg);
 }
 
 /* ============  FACILITY LIST  ============ */
@@ -273,6 +275,11 @@
   grid-template-columns: minmax(180px, 240px) 1fr;
   gap: 18px;
   align-items: start;
+  background: var(--sb-panel-bg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--sb-radius);
+  padding: 18px 20px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.32);
 }
 
 .party-bastion .facility-summary__media {
@@ -289,6 +296,18 @@
   box-shadow: 0 12px 22px rgba(0, 0, 0, 0.35);
 }
 
+.party-bastion .facility-art--interactive {
+  cursor: zoom-in;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.party-bastion .facility-art--interactive:hover,
+.party-bastion .facility-art--interactive:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.4);
+  outline: none;
+}
+
 .party-bastion .facility-title {
   margin: 0;
   font: 700 28px "Modesto Condensed", serif;
@@ -301,7 +320,7 @@
   padding: 12px 14px;
   border-radius: var(--sb-radius);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.35);
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 8px 16px;
@@ -330,9 +349,9 @@
 .party-bastion .facility-description {
   padding: 16px 18px;
   border-radius: var(--sb-radius);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.2);
-  color: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--sb-panel-bg);
+  color: rgba(255, 255, 255, 0.88);
   line-height: 1.5;
 }
 
@@ -356,8 +375,8 @@
 .party-bastion .facility-order-progress {
   padding: 14px 18px 16px;
   border-radius: var(--sb-radius);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--sb-panel-bg);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -456,7 +475,7 @@
   padding: 16px 18px 20px;
   border-radius: var(--sb-radius);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(0, 0, 0, 0.22);
+  background: var(--sb-panel-bg);
 }
 
 .party-bastion .occupant-grid {

--- a/templates/party-bastion-sheet.hbs
+++ b/templates/party-bastion-sheet.hbs
@@ -130,8 +130,12 @@
             <div class="facility-summary__media">
               <img
                 src="{{selectedFacility.img}}"
-                class="facility-art"
+                class="facility-art facility-art--interactive"
                 alt="{{localize 'shared-bastion.ui.facilityImageAlt' name=selectedFacility.name}}"
+                data-facility-id="{{selectedFacility.id}}"
+                role="button"
+                tabindex="0"
+                aria-label="{{localize 'shared-bastion.ui.viewFacilityArt'}}"
               >
             </div>
             <div class="facility-summary__body">


### PR DESCRIPTION
## Summary
- add a shared HTML escaping helper and use it when enriching descriptions or building occupant selectors to avoid the missing `foundry.utils.escapeHTML` runtime error
- activate description/order rich-text listeners, open facility art in an ImagePopout, and fall back to the facility sheet while providing a tooltip shim for Tidy5e
- darken the facility detail panels, occupant blocks, and interactive artwork while adding the localization needed for the new art controls

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74351eb288322a9fe5ef38fb20c79