### PR TITLE
Remove stray closing brace from party sheet

### DIFF
--- a/src/party-bastion-sheet.js
+++ b/src/party-bastion-sheet.js
@@ -1049,7 +1049,6 @@ async _onOrderEdit(ev) {
       console.warn("Shared Bastion | Failed to apply attribution tooltips:", err);
     }
   }
-}
 } // End of PartyBastionSheet class
 
 /* ---------------------------------------------------- */


### PR DESCRIPTION
## Summary
- remove an extra closing brace at the end of `party-bastion-sheet.js` so the file parses correctly as an ES module

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d74691b8088322963631eb123b167c