### PR TITLE
Fix unmatched braces in progress fallback logic

### DIFF
--- a/src/party-bastion-sheet.js
+++ b/src/party-bastion-sheet.js
@@ -435,12 +435,13 @@ r("capitalize", s =>
         const label = foundry.utils.getProperty(raw, "progress.label.value")
           ?? raw.progress?.label;
         if (label) {
-        progress = {
-          current: done ?? 0,
-          max: progressMax ?? null,
-          percent: null,
-          label
-        };
+          progress = {
+            current: done ?? 0,
+            max: progressMax ?? null,
+            percent: null,
+            label
+          };
+        }
       }
 
       results.push({


### PR DESCRIPTION
## Summary
- close the fallback progress branch so the occupant helper is parsed correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75222174c832283df0c0580b4bcf4